### PR TITLE
Fix custom hl groups

### DIFF
--- a/lua/flexoki/highlights/base.lua
+++ b/lua/flexoki/highlights/base.lua
@@ -19,11 +19,11 @@ M.groups = function()
 		["SpellRare"]  = { fg = c['pu'],   bg = 'NONE', underline = true, },
 
 		["NonText"]     = { fg = c['tx-3'], bg = 'NONE' },
-		["EndOfBuffer"] = { fg = 'NONE', bg    = 'NONE' },
+		["EndOfBuffer"] = { fg = 'NONE',    bg = 'NONE' },
 
-		["Search"]     = { fg = c['bg'], bg = c['cy-2'] },
-		["IncSearch"]  = { fg = c['bg'], bg = c['cy-2'] },
-		["Substitute"] = { fg = 'NONE',  bg = c['cy'] },
+		["Search"]     = { fg = c['bg'],  bg = c['cy-2'] },
+		["IncSearch"]  = { fg = c['bg'],  bg = c['cy-2'] },
+		["Substitute"] = { fg = c['bg'],  bg = c['cy-2'] },
 
 		["DiffAdd"]    = { fg = c['bg'],   bg = c['gr'] },
 		["DiffChange"] = { fg = c['bg-2'], bg = c['pu'] },

--- a/lua/flexoki/highlights/base.lua
+++ b/lua/flexoki/highlights/base.lua
@@ -21,8 +21,8 @@ M.groups = function()
 		["NonText"]     = { fg = c['tx-3'], bg = 'NONE' },
 		["EndOfBuffer"] = { fg = 'NONE', bg    = 'NONE' },
 
-		["Search"]     = { fg = c['tx'], bg = c['cy-2'] },
-		["IncSearch"]  = { fg = c['tx'], bg = c['cy-2'] },
+		["Search"]     = { fg = c['bg'], bg = c['cy-2'] },
+		["IncSearch"]  = { fg = c['bg'], bg = c['cy-2'] },
 		["Substitute"] = { fg = 'NONE',  bg = c['cy'] },
 
 		["DiffAdd"]    = { fg = c['bg'],   bg = c['gr'] },

--- a/lua/flexoki/highlights/base.lua
+++ b/lua/flexoki/highlights/base.lua
@@ -19,11 +19,11 @@ M.groups = function()
 		["SpellRare"]  = { fg = c['pu'],   bg = 'NONE', underline = true, },
 
 		["NonText"]     = { fg = c['tx-3'], bg = 'NONE' },
-		["EndOfBuffer"] = { fg = 'NONE',    bg = 'NONE' },
+		["EndOfBuffer"] = { fg = 'NONE', bg    = 'NONE' },
 
-		["Search"]     = { fg = c['bg'],  bg = c['cy-2'] },
-		["IncSearch"]  = { fg = c['bg'],  bg = c['cy-2'] },
-		["Substitute"] = { fg = c['bg'],  bg = c['cy-2'] },
+		["Search"]     = { fg = c['tx'], bg = c['cy-2'] },
+		["IncSearch"]  = { fg = c['tx'], bg = c['cy-2'] },
+		["Substitute"] = { fg = 'NONE',  bg = c['cy'] },
 
 		["DiffAdd"]    = { fg = c['bg'],   bg = c['gr'] },
 		["DiffChange"] = { fg = c['bg-2'], bg = c['pu'] },

--- a/lua/flexoki/theme.lua
+++ b/lua/flexoki/theme.lua
@@ -6,11 +6,10 @@ local M = {}
 
 ---@param opts FlexokiOptions
 M.set_highlights = function(opts)
-
 	local highlight_groups = highlights.groups()
 
 	-- Set users highlight_group customisations.
-	if not opts.highlight_groups == nil then
+	if opts.highlight_groups ~= nil then
 		for group, highlight in pairs(opts.highlight_groups) do
 			highlight_groups[group] = highlight
 		end


### PR DESCRIPTION
I am manually calling `flexoki.colorscheme` and setting custom `highlight_groups`. I discovered my custom `highlight_groups` were no be honored by running `so $VIMRUNTIME/syntax/hitest.vim`. By changing this condition from `not ...` to `~=` the custom highlight groups starting working as expected. I'm no lua expert, open to other approaches.